### PR TITLE
Two fixes/updates

### DIFF
--- a/leaflet.geocsv-src.js
+++ b/leaflet.geocsv-src.js
@@ -58,13 +58,13 @@ L.GeoCSV = L.GeoJSON.extend({
       //generamos _propertiesNames
       for (var i=0; i<titulos.length; i++) {
          var prop = titulos[i].toLowerCase().replace(/[^\w ]+/g,'').replace(/ +/g,'_');
-         if (prop == '' || prop == '_' || this._propertiesNames.indexOf(prop) >= 0) prop = 'prop-'+i;
+         if (prop == '' || prop == '_') prop = 'prop-'+i;
          this._propertiesNames[i] = prop;
       }
       //convertimos los datos a geoJSON
       data = this._csv2json(data);
     }
-    L.GeoJSON.prototype.addData.call (this, data);
+    return L.GeoJSON.prototype.addData.call (this, data);
   },
 
   getPropertyName: function (title) {


### PR DESCRIPTION
First issue appears if you addData twice with the firstLineTitles = false. On the second load the titles text would be overwritten with prop-0, prop-1, ... This was due to the this._propertiesNames.indexOf(prop) >= 0 which should not be set.

Second the base method for addData returned the added layer, I use this and had to add the return (which should have been there anyway).